### PR TITLE
fix(institutions): no is a special keyword in yaml

### DIFF
--- a/nr_vocabularies/fixtures/institutions.yaml
+++ b/nr_vocabularies/fixtures/institutions.yaml
@@ -3078,7 +3078,7 @@ relatedURI:
   ROR: https://ror.org/03zga2b32
   URL: https://www.uib.no/en
 nonpreferredLabels:
-- no: Universitetet i Bergen
+- 'no': Universitetet i Bergen
 title:
   en: University of Bergen
 ---

--- a/tests/test_import_export.py
+++ b/tests/test_import_export.py
@@ -12,7 +12,7 @@ def test_complex_import_export(app, db, cache, search_clear, vocab_cf, caplog):
     load_fixtures(batch_size=100, callback=load_callback)
     assert load_callback.failed_entries_count == 0
     assert load_callback.filtered_entries_count == 0
-    assert load_callback.ok_entries_count == 1214
+    assert load_callback.ok_entries_count == 1222
     Vocabulary.index.refresh()
 
     with tempfile.TemporaryDirectory() as d:


### PR DESCRIPTION
In the YAML standard, no is a reserved keyword meaning False, and needs to be quoted as `'no'` (e.g. when used as a language code for Norwegian - fyi @Wyvi )